### PR TITLE
Typo in MWEM example

### DIFF
--- a/whitepaper-demos/2-reidentification-attack.ipynb
+++ b/whitepaper-demos/2-reidentification-attack.ipynb
@@ -897,7 +897,7 @@
    "source": [
     "%%time\n",
     "# Apply the synthesizer to the data set\n",
-    "synthetic_data = MWEMSynthesizer(Q_count = 400,\n",
+    "synthetic_data = MWEMSynthesizer(q_count = 400,\n",
     "                        epsilon = 3.00,\n",
     "                        iterations = 60,\n",
     "                        mult_weights_iterations = 40,\n",


### PR DESCRIPTION
We had a typo in a parameter name that was causing white paper demo notebook 2 to fail.  Fixed now.